### PR TITLE
Update MandrillTransport.php

### DIFF
--- a/Lib/Network/Email/MandrillTransport.php
+++ b/Lib/Network/Email/MandrillTransport.php
@@ -112,7 +112,9 @@ class MandrillTransport extends AbstractTransport {
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_USERAGENT, 'Mandrill-PHP/1.0.52');
         curl_setopt($ch, CURLOPT_POST, true);
-        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+        if (!ini_get('safe_mode') && !ini_get('open_basedir')){
+            curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+        }
         curl_setopt($ch, CURLOPT_HEADER, false);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 30);


### PR DESCRIPTION
Added a check to see if both safe_mode and open_basedir are not set.  CURLOPT_FOLLOWLOCATION can't be set if either safe_mode or open_basedir are set.
